### PR TITLE
bugfix: can not broadcast new object record to players

### DIFF
--- a/NFComm/NFKernelPlugin/NFCSceneAOIModule.cpp
+++ b/NFComm/NFKernelPlugin/NFCSceneAOIModule.cpp
@@ -465,6 +465,7 @@ int NFCSceneAOIModule::OnClassCommonEvent(const NFGUID & self, const std::string
 			//monster or others need to tell all player
 			OnObjectListEnter(valueAllPlayrObjectList, NFDataList() << self);
 			OnPropertyEnter(valueAllPlayrObjectList, self);
+			OnRecordEnter(valueAllPlayrObjectList, self);
 
 			OnObjectListEnterFinished(valueAllPlayrObjectList, NFDataList() << self);
 


### PR DESCRIPTION
副本中新创建的对象的Record没有广播给所有玩家