### PR TITLE
fix Utf8ToGbk BUG

### DIFF
--- a/NFTools/NFFileProcess/Utf8ToGbk.h
+++ b/NFTools/NFFileProcess/Utf8ToGbk.h
@@ -91,20 +91,12 @@ extern "C" {
 				indexUtf8++;
 				continue;
 			}
-			gbk = uni2gbk[unicode];
-			if (lenTmp == 3) {
-				strgbk[indexGbk++] = gbk >> 8;
-				strgbk[indexGbk++] = gbk & 0xFF;
-			}
-			else if (lenTmp == 1) {
-				strgbk[indexGbk++] = gbk & 0xFF;
-			}
-			else if (lenTmp == 2) {
-				strgbk[indexGbk++] = gbk >> 8;
-				strgbk[indexGbk++] = gbk & 0xFF;
-			}
-			else if (lenTmp == 4) {
-				strgbk[indexGbk++] = gbk >> 8;
+			if (unicode >= sizeof uni2gbk / sizeof *uni2gbk) {}
+			else
+			{
+				gbk = uni2gbk[unicode];
+				if (lenTmp > 1)
+					strgbk[indexGbk++] = gbk >> 8;
 				strgbk[indexGbk++] = gbk & 0xFF;
 			}
 			indexUtf8 += lenTmp;


### PR DESCRIPTION
Utf8 some 4 byte codes cannot be converted into gbk. 
Beyond the range of the coded mapping table
For example, "😀"
You can only skip, or you'll be fail