### PR TITLE
Bug fix: May not have game server to select when multi-servers config…

### DIFF
--- a/NFServer/NFProxyServerNet_ServerPlugin/NFCProxyServerNet_ServerModule.cpp
+++ b/NFServer/NFProxyServerNet_ServerPlugin/NFCProxyServerNet_ServerModule.cpp
@@ -280,9 +280,10 @@ void NFCProxyServerNet_ServerModule::OnSelectServerProcess(const NFSOCK nSockInd
 	int nGameID = 0;
     NFMapEx<int, ConnectData>& xServerList = m_pNetClientModule->GetServerList();
     ConnectData* pGameData = xServerList.FirstNude();
-    while (pGameData && NF_SERVER_TYPES::NF_ST_GAME == pGameData->eServerType)
+    while (pGameData)
     {
-        if (ConnectDataState::NORMAL == pGameData->eState)
+        if (ConnectDataState::NORMAL == pGameData->eState
+            && NF_SERVER_TYPES::NF_ST_GAME == pGameData->eServerType)
         {
 			if (pGameData->nWorkLoad < nWorkload)
 			{


### PR DESCRIPTION
当配置多个worldserver或者多个gameserver时，m_pNetClientModule->GetServerList()返回的map中，第一个元素的类型未必是GameServer，因而导致While循环中断，无法返回合适的game服务器给客户端。