### PR TITLE
fixed bug for actor

### DIFF
--- a/NFComm/NFActorPlugin/NFCActorModule.cpp
+++ b/NFComm/NFActorPlugin/NFCActorModule.cpp
@@ -124,7 +124,7 @@ bool NFCActorModule::ExecuteEvent()
 			NF_SHARE_PTR<NFIActor> xActor = mxActorMap.GetElement(xMsg.nFormActor);
 			if (xActor)
 			{
-				mxActorMap.RemoveElement(xMsg.nFormActor);
+				//mxActorMap.RemoveElement(xMsg.nFormActor);
 				mxActorPool.Push(xActor);
 			}
 		}


### PR DESCRIPTION
因为在NFCActorModule::ExecuteEvent() 不调用释放Actor，所以也不能remove掉Actor，不然第二次调用SendMsgToActor时调用GetActor（）会返回一个null。

群主大大太粗心了╮(╯﹏╰）╭