### PR TITLE
Fix SetNodeSize bug, which assign value to itself.

### DIFF
--- a/NFComm/NFRenderPlugin/UI/NFNodeSystem.cpp
+++ b/NFComm/NFRenderPlugin/UI/NFNodeSystem.cpp
@@ -181,7 +181,7 @@ namespace NodeSystem
 
     void NFNodeSystem::SetNodeSize(const int size)
     {
-        this->nodeSize = nodeSize;
+        this->nodeSize = size;
     }
 
     int NFNodeSystem::GetNodeSize()


### PR DESCRIPTION
in NFComm/NFRenderPlugin/UI/NFNodeSystem.cpp, Line 182:
```
    void NFNodeSystem::SetNodeSize(const int size)
    {
        this->nodeSize = nodeSize;
    }

```

The assignment of nodeSize has obvious bug. Thus, change it to:

```
    void NFNodeSystem::SetNodeSize(const int size)
    {
        this->nodeSize = size;
    }

```
